### PR TITLE
Unban `and` and `or` control flow operators

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1420,57 +1420,63 @@ def banned?
 end
 ----
 
-=== `and`/`or` [[no-and-or-or]]
+=== `and`/`or` [[no-and-or-or]] [[and-or-flow]]
 
-The `and` and `or` keywords are banned.
-The minimal added readability is just not worth the high probability of introducing subtle bugs.
-For boolean expressions, always use `&&` and `||` instead.
-For flow control, use `if` and `unless`; `&&` and `||` are also acceptable but less clear.
+`and` and `or` are control flow operators. They have very low precedence, and should only be used
+as a final fallback statements.
 
 [source,ruby]
 ----
 # bad
-# boolean expression
-ok = got_needed_arguments and arguments_are_valid
-
-# control flow
-document.save or raise("Failed to save document!")
+# and/or in conditions
+if got_needed_arguments and arguments_valid
+  # ...body omitted
+end
+# in logical expression calculation
+ok = got_needed_arguments and arguments_valid
 
 # good
-# boolean expression
-ok = got_needed_arguments && arguments_are_valid
+# &&/|| in conditions
+if got_needed_arguments && arguments_valid
+  # ...body omitted
+end
+# in logical expression calculation
+ok = got_needed_arguments && arguments_valid
 
-# control flow
-raise("Failed to save document!") unless document.save
+# bad
+# &&/|| for control flow (can lead to very surprising results)
+x = extract_arguments || raise(ArgumentError, "Not enough arguments!")
 
-# ok
-# control flow
-document.save || raise("Failed to save document!")
+# good: and/or for control flow
+x = extract_arguments or raise ArgumentError, "Not enough arguments!"
+user.suspended? and return :denied
 ----
 
-.Why Ban `and` and `or`?
-****
-The main reason is very simple - they add a lot of cognitive overhead, as they don't behave like similarly named operators in other languages.
-
-First of all, `and` and `or` operators have lower precedence than the `=` operator, whereas the `&&` and `||` operators have higher precedence than the `=` operator, based on order of operations.
+But avoid several control flow operators in one expression, that becomes
+confusing:
 
 [source,ruby]
 ----
-foo = true and false # results in foo being equal to true. Equivalent to ( foo = true ) and false
-bar = false or true  # results in bar being equal to false. Equivalent to ( bar = false ) or true
-----
+# bad
+# Did author mean conditional return because `#log` could result in `nil`?
+# ...or was it just to have a smart one-liner?
+x = extract_arguments and log("extracted") and return
 
-Also `&&` has higher precedence than `||`, where as `and` and `or` have the same one. Funny enough, even though `and` and `or`
-were inspired by Perl, they don't have different precedence in Perl.
+# good
+# If the intention was conditional return
+x = extract_arguments
+if x
+  return if log("extracted")
+end
+# If the intention was just "log, then return"
+x = extract_arguments
+if x
+  log("extracted")
+  return
+end
+---
 
-[source,ruby]
-----
-foo = true or true and false # => false (it's effectively (true or true) and false)
-foz = true || true && false # => true (it's effectively true || (true && false)
-bar = false or true and false # => false (it's effectively (false or true) and false)
-baz = false || true && false # => false (it's effectively false || (true && false))
-----
-****
+NOTE: whether organizing control flow with `and` and `or` is a good idea was a controversial topic in community for a long time. But if you do, use these operators and not `&&`/`||`.
 
 === Multi-line Ternary Operator [[no-multiline-ternary]]
 

--- a/README.adoc
+++ b/README.adoc
@@ -1422,13 +1422,19 @@ end
 
 === `and`/`or` [[no-and-or-or]] [[and-or-flow]]
 
-`and` and `or` are control flow operators. They have very low precedence, and should only be used
-as a final fallback statements.
+`and` and `or` are control flow operators. They have very low precedence, and can be used as a short
+form of specifying flow sequences like "evaluate expression 1, and only if it is not successful
+(returned `nil`), evaluate expression 2". This is especially useful for raising errors or early
+return without breaking the reading flow.
 
 [source,ruby]
 ----
+# good: and/or for control flow
+x = extract_arguments or raise ArgumentError, "Not enough arguments!"
+user.suspended? and return :denied
+
 # bad
-# and/or in conditions
+# and/or in conditions (their precedence is low, might produce unexpected result)
 if got_needed_arguments and arguments_valid
   # ...body omitted
 end
@@ -1446,10 +1452,6 @@ ok = got_needed_arguments && arguments_valid
 # bad
 # &&/|| for control flow (can lead to very surprising results)
 x = extract_arguments || raise(ArgumentError, "Not enough arguments!")
-
-# good: and/or for control flow
-x = extract_arguments or raise ArgumentError, "Not enough arguments!"
-user.suspended? and return :denied
 ----
 
 But avoid several control flow operators in one expression, that becomes
@@ -1476,7 +1478,7 @@ if x
 end
 ---
 
-NOTE: whether organizing control flow with `and` and `or` is a good idea was a controversial topic in community for a long time. But if you do, use these operators and not `&&`/`||`.
+NOTE: Whether organizing control flow with `and` and `or` is a good idea was a controversial topic in the community for a long time. But if you do, prefer these operators over `&&`/`||`.
 
 === Multi-line Ternary Operator [[no-multiline-ternary]]
 


### PR DESCRIPTION
And so, after several years of private discussions, here I am!

My reasoning goes as this:

1. I remember/understand where the current state of the rule came from. Initially, `and`/`or` were understood by most of the community (and previous versions of this guide) as "broken logical operators" with surprisingly low priority, and, to add insult to injury, equal priority towards each other (unlike usual higher priority of logical "and"). But, as time went and approaches to Ruby style and coding practices became crystallized, it became obvious that `and`/`or` were designed for **control flow**, and their design is extremely suitable for this task, as shown by examples below:
  ```ruby
  # parsing and evaluation priority allows to use and/or as clear precondition for methods:
  value = fetch_necessary_value or raise Error, "Pretty long error message"
  value = fetch_optional_value or return

  # their different spelling and priority are good for mixing them with logical evaluation
  possible_error_check || other_possible_error && condition_for_that_error and raise
  # There is **no** clear and DRY replacements for examples above.
  ```
2. This style guide went a long road since its inception. In current state, it is de-facto "**The** Style Guide", one that novices are immediately exposed to, one that The Linter (aka Rubocop) implements with default settings. With this in mind, stakes for "doing right" in style guide are much higher than their were yeas ago, it is a lot of responsibility for entire community/infrastructure. "Banning" of useful, clearly designed language feature with readable usages and obvious meaning seems just plain wrong—**despite** possible discussions of who prefers what.
3. It is important to observe that the style guide does NOT, in current state, totally against flow control with "and"/"or", but advices (inappropriately) `&&` and `||` for it, which do not allow most of the good usages of flow control! It is slightly like "screwdrivers are banned; use your pocket knife to screw things".
4. Aside observation: no other language feature is "banned". Some are recommended to "avoid", most of the time with explanantion _why_ and/or recommendations _what_ should be used instead; the esoteric flip-flops are almost the only thing that just commented with "avoid, period", but even `for` recommendation is softened with "unless you know exactly why". So, this "personal hostility" towards this particular feature looks obviously outdated.
5. The last objection to `and`/`or` that could be thought of is their equal priority. I believe that it doesn't matter at all, as for the flow control more than one flow-control operator in a row is weird anyways (and my proposed change advices on that). _As a one more side note, I assume that idea of equal priority came exactly from "flow control" domain: to avoid "reordering" of flow statements, in examples like: `output or log and exit` ("regular" priorities would read it as `output or (log and exit)`, so no `exit` if `output` was successful, "flat" priorities would do `(output or log) and exit`). I agree it **could** be thought as convoluted, and, again, advice against combining flow control operators._

I believe this justifies the change proposed.

**NB**: I am preserving `#no-and-or-or` anchor (in addition to the new `#and-or-flow` anchor), in order to old links to this rule still work (but leading to the new rule).