### PR TITLE
Optional Keyword Arguments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2548,7 +2548,7 @@ some_method('w', 'x', 'y') # => 'y, 2, w, x'
 some_method('w', 'x', 'y', 'z') # => 'y, z, w, x'
 ----
 
-=== Optional Keyword Arguments [[optional-keywordarguments]]
+=== Keyword Arguments Order [[keyword-arguments-order]]
 
 When using optional keyword arguments, put them at the end of the parameters list.
 When looking through the source, you expect required arguments at the beginning of parameters list and optional arguments at the end.

--- a/README.adoc
+++ b/README.adoc
@@ -2550,8 +2550,7 @@ some_method('w', 'x', 'y', 'z') # => 'y, z, w, x'
 
 === Keyword Arguments Order [[keyword-arguments-order]]
 
-When using optional keyword arguments, put them at the end of the parameters list.
-When looking through the source, you expect required arguments at the beginning of parameters list and optional arguments at the end.
+Put required keyword arguments before optional keyword arguments.
 
 [source,ruby]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -2548,19 +2548,19 @@ some_method('w', 'x', 'y') # => 'y, 2, w, x'
 some_method('w', 'x', 'y', 'z') # => 'y, z, w, x'
 ----
 
-=== Keyword Arguments Order [[keyword-arguments-order]]
+=== Keyword Arguments Order
 
-Put required keyword arguments before optional keyword arguments.
+Put required keyword arguments before optional keyword arguments. Otherwise, it's much harder to spot optional arguments there, if they're hidden somewhere in the middle.
 
 [source,ruby]
 ----
 # bad
-def some_method(first: false, second:, third: 10)
+def some_method(foo: false, bar:, baz: 10)
   # body omitted
 end
 
 # good
-def some_method(second:, first: false, third: 10)
+def some_method(foo:, bar: false, baz: 10)
   # body omitted
 end
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -2548,6 +2548,24 @@ some_method('w', 'x', 'y') # => 'y, 2, w, x'
 some_method('w', 'x', 'y', 'z') # => 'y, z, w, x'
 ----
 
+=== Optional Keyword Arguments [[optional-keywordarguments]]
+
+When using optional keyword arguments, put them at the end of the parameters list.
+When looking through the source, you expect required arguments at the beginning of parameters list and optional arguments at the end.
+
+[source,ruby]
+----
+# bad
+def some_method(first: false, second:, third: 10)
+  # body omitted
+end
+
+# good
+def some_method(second:, first: false, third: 10)
+  # body omitted
+end
+----
+
 === Boolean Keyword Arguments [[boolean-keyword-arguments]]
 
 Use keyword arguments when passing boolean argument to a method.


### PR DESCRIPTION
When using optional keyword arguments, put them at the end of the parameters list.

Otherwise, it's much harder to spot optional arguments there, if they're hidden somewhere in the middle.