### PR TITLE
add 'prepend' to Consistent Classes section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2622,9 +2622,10 @@ Use a consistent structure in your class definitions.
 [source,ruby]
 ----
 class Person
-  # extend and include go first
+  # extend/include/prepend go first
   extend SomeModule
   include AnotherModule
+  prepend YetAnotherModule
 
   # inner classes
   CustomError = Class.new(StandardError)


### PR DESCRIPTION
Add missed `prepend` keyword into the description of class definitions:
https://github.com/rubocop-hq/ruby-style-guide#consistent-classes