### PR TITLE
Add "Semicolon in `in`" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1333,6 +1333,23 @@ NOTE: The alternative syntax `when x: ...` has been removed as of Ruby 1.9.
 
 Do not use `when x; ...`. See the previous rule.
 
+=== Semicolon in `in` [[no-in-pattern-semicolons]]
+
+Do not use `in pattern; ...`. Use `in pattern then ...` for one-line `in` pattern branches.
+
+[source,ruby]
+----
+# bad
+case expression
+in pattern; do_something
+end
+
+# good
+case expression
+in pattern then do_something
+end
+----
+
 === `!` vs `not` [[bang-not-not]]
 
 Use `!` instead of `not`.


### PR DESCRIPTION
This PR adds "Semicolon in `in`" rule for Ruby 2.7's pattern matching syntax.

This rule is similar to the "Semicolon in `when`" rule.
https://rubystyle.guide/#no-when-semicolons