### PR TITLE
feat: flip-flop statements no longer deprecated

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5334,8 +5334,6 @@ Fix by either:
 
 Avoid the use of flip-flops.
 
-NOTE: They are deprecated as of Ruby 2.6.
-
 === No non-`nil` Checks [[no-non-nil-checks]]
 
 Don't do explicit non-`nil` checks unless you're dealing with boolean values.


### PR DESCRIPTION
Flip-Flop statements are no longer deprecated per ruby bugs 5400.
Remove deprecated note.

See: https://bugs.ruby-lang.org/issues/5400