### PR TITLE
Fix typo in "Unused Variable Prefix" section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1082,7 +1082,7 @@ end
 
 Prefix with `+_+` unused block parameters and local variables.
 It's also acceptable to use just `+_+` (although it's a bit less descriptive).
-This convention is recognized by the Ruby interpreter and tools like RuboCop and will suppress their unused variable warnings.
+This convention is recognized by the Ruby interpreter and tools like RuboCop will suppress their unused variable warnings.
 
 [source,ruby]
 ----


### PR DESCRIPTION
I couldn't figure out what word was supposed to go after "and" so I got rid of it.