### PR TITLE
Add bad and good examples for empty lines between methods

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -481,6 +481,17 @@ Use empty lines between method definitions and also to break up methods into log
 
 [source,ruby]
 ----
+# bad
+def some_method
+  data = initialize(options)
+  data.manipulate!
+  data.result
+end
+def some_other_method
+  result
+end
+
+# good
 def some_method
   data = initialize(options)
 
@@ -489,7 +500,7 @@ def some_method
   data.result
 end
 
-def some_method
+def some_other_method
   result
 end
 ----


### PR DESCRIPTION
In the section `Empty Lines between methods` -

No `# bad` or `# good` example added, so `# good` was assumed.  

Let's be explicit about which is a good example and bad example. 