### PR TITLE
Add new "Hash Literal Values" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4116,6 +4116,19 @@ hash = { :one => 1, :two => 2, :three => 3 }
 hash = { one: 1, two: 2, three: 3 }
 ----
 
+=== Hash Literal Values
+
+Use the Ruby 3.1 hash literal value syntax when your hash key and value are the same.
+
+[source,ruby]
+----
+# bad
+hash = { one: one, two: two, three: three }
+
+# good
+hash = { one:, two:, three: }
+----
+
 === Hash Literal as Last Array Item [[hash-literal-as-last-array-item]]
 
 Wrap hash literal in braces if it is a last array item.


### PR DESCRIPTION
## Summary

Ruby 3.1 will be introduced hash shorthand syntax:
https://bugs.ruby-lang.org/issues/17292.

This rule defines hash literal value syntax.

```ruby
# bad
{foo: foo, bar: bar}

# good
{foo:, bar:}
```

## Additional Information

This rule is based on the upgrade from ES5 to ES6 with ESLint.

The ES6 shorthand syntax is chosen by default for ESLint shorthands:

> "always" (default) expects that the shorthand will be used whenever possible.

https://eslint.org/docs/rules/object-shorthand

The rule will also define the new Ruby 3.1 shorthand syntax by default.