### PR TITLE
Add new "Block Forwarding" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3101,6 +3101,25 @@ def some_method(...)
 end
 ----
 
+=== Block Forwarding
+
+Use Ruby 3.1's anonymous block forwarding.
+
+In most cases, block argument is given name similar to `&block` or `&proc`. Their names have no information and `&` will be sufficient for syntactic meaning.
+
+[source,ruby]
+----
+# bad
+def some_method(&block)
+  other_method(&block)
+end
+
+# good
+def some_method(&)
+  other_method(&)
+end
+----
+
 === Private Global Methods [[private-global-methods]]
 
 If you really need "global" methods, add them to Kernel and make them private.


### PR DESCRIPTION
Ruby 3.1 will be introduced anonymous block forwarding syntax:
https://bugs.ruby-lang.org/issues/11256

```ruby
# bad
def some_method(&block)
  other_method(&block)
end

# good
def some_method(&)
  other_method(&)
end
```

AFAIK, in most cases, block argument is given name similar to `&block` or `&proc`. Their names have no information and `&` will be sufficient for syntactic meaning.