### PR TITLE
Remove definite article from title

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= The Ruby Style Guide
+= Ruby Style Guide
 :idprefix:
 :idseparator: -
 :sectanchors:


### PR DESCRIPTION
Using the definite article `the` could imply this is the 'one true' or 'official' style guide. Although it's certainly the most commonly used and referenced, I think this is an important distinction to make.

(if this is accepted, I'll make corresponding updates to the Rails Style Guide, etc.)