### PR TITLE
Limit some examples to be just logical expression and not assignments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1499,10 +1499,10 @@ were inspired by Perl, they don't have different precedence in Perl.
 
 [source,ruby]
 ----
-foo = true or true and false # => false (it's effectively (true or true) and false)
-foz = true || true && false # => true (it's effectively true || (true && false)
-bar = false or true and false # => false (it's effectively (false or true) and false)
-baz = false || true && false # => false (it's effectively false || (true && false))
+true or true and false # => false (it's effectively (true or true) and false)
+true || true && false # => true (it's effectively true || (true && false)
+false or true and false # => false (it's effectively (false or true) and false)
+false || true && false # => false (it's effectively false || (true && false))
 ----
 ****
 


### PR DESCRIPTION
In the section "Why is using and and or as logical operators a bad idea?" ...

Notice the example following given example:

```
foo = true or true and false # => false (it's effectively (true or true) and false)
```

Yes, the whole expression is `false` but be careful: `foo` is `true`.

This phenomenal of problems with the assignment was already addressed by the previous example:

```
----
foo = true and false # results in foo being equal to true. Equivalent to (foo = true) and false
bar = false or true  # results in bar being equal to false. Equivalent to (bar = false) or true
----
```

So my suggestion is to limit this last examples to just be logical expressions, or add for each one a new "column" for the variable value. Something enough to express:

expression # expression's value # variable's value
foo = true or true and false # false # true
foz = true || true && false # true # true
bar = false or true and false # false # false
baz = false || true && false # false # false