### PR TITLE
Add new "Operator Method Call" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -255,6 +255,19 @@ puts 'bar'
 puts 'foo', 'bar' # this applies to puts in particular
 ----
 
+=== Operator Method Call
+
+Avoid dot where not required for operator method calls.
+
+[source,ruby]
+----
+# bad
+num.+ 42
+
+# good
+num + 42
+----
+
 === Spaces and Operators [[spaces-operators]]
 
 Use spaces around operators, after commas, colons and semicolons.


### PR DESCRIPTION
Avoid dot where not required for operator method calls.

```ruby
# bad
num.+ 42

# good
num + 42
```

This rule corresponds to https://github.com/rubocop/rubocop/pull/11080.