### PR TITLE
Change "Consisten Classes" example to be consistent with style guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3210,7 +3210,8 @@ class Person
   prepend YetAnotherModule
 
   # inner classes
-  CustomError = Class.new(StandardError)
+  class CustomError < StandardError
+  end
 
   # constants are next
   SOME_CONSTANT = 20


### PR DESCRIPTION
The example for the "Consistent Classes" section previously used a bad single-line declaration for the inner class, called out two sections below in "Single-line Classes". This PR fixes this inconsistency and applies the recommended two line format.