### PR TITLE
Add guideline for using safe operator.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -325,29 +325,32 @@ foo&.bar
 
 === Safe navigation
 
-Avoid long chains of `&.` replace with `.`, if safe navigator operator introduce unnecessary conditional logic.
-Consider other approaches such as delegation.
+Avoid chaining of `&.`. Replace with `.` and an explicit check.
+E.g. if users are guaranteed to have an address and addresses are guaranteed to have a zip code:
 
-If users are guaranteed to have an address and addresses are guaranteed to have a zip code:
-
-[source, thoughtbot]
+[source, ruby]
 ----
 # bad
 user&.address&.zip
 
 #good 
 user && user.address.zip
+----
+
+If such a change introduces excessive conditional logic, consider other approaches, such as delegation:
+[source, ruby]
+----
+#bad
+user && user.address && user.address.zip
 
 #good
 class User
   def zip
-    address.zip
+    address&.zip
   end
 end
-
 user&.zip
 ----
-
 === Spaces and Braces [[spaces-braces]]
 
 No spaces after `(`, `[` or before `]`, `)`.

--- a/README.adoc
+++ b/README.adoc
@@ -325,7 +325,7 @@ foo&.bar
 
 === Safe navigation
 
-Avoid long chains of `&.`. Replace with `.` if they introduce unnecessary conditional logic. 
+Avoid long chains of `&.`. Replace with `.`. if safe navigator operator introduce unnecessary conditional logic.
 Consider other approaches such as delegation.
 
 For condition where users are guaranteed to have an address and addresses are guaranteed to have a zip code

--- a/README.adoc
+++ b/README.adoc
@@ -323,6 +323,29 @@ foo&. bar
 foo&.bar
 ----
 
+=== Safe navigation
+
+Avoid long chains of `&.`. Replace with `.` if they introduce unnecessary conditional logic. 
+Consider other approaches such as delegation.
+
+For condition where users are guaranteed to have an address and addresses are guaranteed to have a zip code
+
+[source, thoughtbot(https://thoughtbot.com/blog/ruby-safe-navigation#conditional-equivalence)]
+# bad
+user&.address&.zip
+
+#good 
+user && user.address.zip
+
+#good
+class User
+  def zip
+    address.zip
+  end
+end
+
+user&.zip
+
 === Spaces and Braces [[spaces-braces]]
 
 No spaces after `(`, `[` or before `]`, `)`.

--- a/README.adoc
+++ b/README.adoc
@@ -328,7 +328,7 @@ foo&.bar
 Avoid long chains of `&.` replace with `.`, if safe navigator operator introduce unnecessary conditional logic.
 Consider other approaches such as delegation.
 
-For condition where users are guaranteed to have an address and addresses are guaranteed to have a zip code
+If users are guaranteed to have an address and addresses are guaranteed to have a zip code:
 
 [source, thoughtbot]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -330,7 +330,7 @@ Consider other approaches such as delegation.
 
 For condition where users are guaranteed to have an address and addresses are guaranteed to have a zip code
 
-[source, thoughtbot(https://thoughtbot.com/blog/ruby-safe-navigation#conditional-equivalence)]
+[source, thoughtbot]
 # bad
 user&.address&.zip
 

--- a/README.adoc
+++ b/README.adoc
@@ -331,6 +331,7 @@ Consider other approaches such as delegation.
 For condition where users are guaranteed to have an address and addresses are guaranteed to have a zip code
 
 [source, thoughtbot]
+----
 # bad
 user&.address&.zip
 
@@ -345,6 +346,7 @@ class User
 end
 
 user&.zip
+----
 
 === Spaces and Braces [[spaces-braces]]
 

--- a/README.adoc
+++ b/README.adoc
@@ -325,7 +325,7 @@ foo&.bar
 
 === Safe navigation
 
-Avoid long chains of `&.`. Replace with `.`. if safe navigator operator introduce unnecessary conditional logic.
+Avoid long chains of `&.` replace with `.`, if safe navigator operator introduce unnecessary conditional logic.
 Consider other approaches such as delegation.
 
 For condition where users are guaranteed to have an address and addresses are guaranteed to have a zip code


### PR DESCRIPTION
[#889](https://github.com/rubocop/ruby-style-guide/issues/889) - Add guidance for safe navigation operator (&.) 
Based on the 889 issue added guidelines for using safe navigation operators using some resources from the thought bot.

The idea here is to not use a safe navigation operator in unnecessary chaining which may lead to confusion to the reader regarding the existence of the object instead use delegation.

NOTE: This is my first pr so if there is any suggestion please let me know thanks in advance :).
