### PR TITLE
Use and/or operators for control flow as recommended

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1554,7 +1554,7 @@ Avoid multi-line `?:` (the ternary operator); use `if`/`unless` instead.
 === `if` as a Modifier [[if-as-a-modifier]]
 
 Prefer modifier `if`/`unless` usage when you have a single-line body.
-Another good alternative is the usage of control flow `&&`/`||`.
+Another good alternative is the usage of control flow `and`/`or`.
 
 [source,ruby]
 ----
@@ -1567,7 +1567,7 @@ end
 do_something if some_condition
 
 # another good option
-some_condition && do_something
+some_condition and do_something
 ----
 
 === Multi-line `if` Modifiers [[no-multiline-if-modifiers]]


### PR DESCRIPTION
The style guide recommends and/or operators for control flow:

```ruby
# good: and/or for control flow
x = extract_arguments or raise ArgumentError, "Not enough arguments!"
user.suspended? and return :denied

# bad
# &&/|| for control flow (can lead to very surprising results)
x = extract_arguments || raise(ArgumentError, "Not enough arguments!")
```

However, this one section goes against the recommendation.