### PR TITLE
Add a new bad example to the "Proc Application Shorthand" section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2584,6 +2584,9 @@ Use the Proc call shorthand when the called method is the only operation of a bl
 # bad
 names.map { |name| name.upcase }
 
+# bad
+names.map { _1.upcase }
+
 # good
 names.map(&:upcase)
 ----


### PR DESCRIPTION
Use the Proc call shorthand when the block has only one numbered parameter as a receiver.