### PR TITLE
Fix inaccuracy in the Keyword Arguments Order

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3115,7 +3115,7 @@ some_method('w', 'x', 'y', 'z') # => 'y, z, w, x'
 
 === Keyword Arguments Order
 
-Put required keyword arguments before optional keyword arguments. Otherwise, it's much harder to spot optional arguments there, if they're hidden somewhere in the middle.
+Put required keyword arguments before optional keyword arguments. Otherwise, it's much harder to spot optional keyword arguments there, if they're hidden somewhere in the middle.
 
 [source,ruby]
 ----


### PR DESCRIPTION
Optional arguments are not the same as optional keyword arguments. Since we're talking about keyword arguments here, it's better to clarify this point.