### PR TITLE
Fix broken text formatting in String Concatenation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4876,9 +4876,9 @@ message = "This is the #{result}."
 
 === String Concatenation [[concat-strings]]
 
-Avoid using `String#+` when you need to construct large data chunks.
+Avoid using `pass:[String#+]` when you need to construct large data chunks.
 Instead, use `String#<<`.
-Concatenation mutates the string instance in-place and is always faster than `String#+`, which creates a bunch of new string objects.
+Concatenation mutates the string instance in-place and is always faster than `pass:[String#+]`, which creates a bunch of new string objects.
 
 [source,ruby]
 ----


### PR DESCRIPTION
The text in [String Concatenation](https://github.com/rubocop/ruby-style-guide#concat-strings) is not rendered correctly because `+` means [literal text](https://docs.asciidoctor.org/asciidoc/latest/text/literal-monospace/) without formatting. It can be fixed by adding the passthrough macros. Additionally, I noticed that this is a relatively [new feature](https://github.com/asciidoctor/asciidoctor/issues/4458) in Asciidoctor.