### PR TITLE
Add empty line after guard clause in Nested Conditionals

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1903,8 +1903,11 @@ end
 # good
 def compute_thing(thing)
   return unless thing[:foo]
+
   update_with_bar(thing[:foo])
+
   return re_compute(thing) unless thing[:foo][:bar]
+
   partial_compute(thing)
 end
 ----
@@ -1923,6 +1926,7 @@ end
 # good
 [0, 1, 2, 3].each do |item|
   next unless item > 1
+
   puts item
 end
 ----


### PR DESCRIPTION
This PR adds empty lines after guard clauses in the "Nested Conditionals" section. This helps maintain best practices even when explaining other cases.