### PR TITLE
Add section on null devices

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2294,6 +2294,22 @@ end
 FileUtils.rm_f(path)
 ----
 
+=== Null Devices [[null-devices]]
+
+Use the platform independent null device (`File::NULL`) rather than hardcoding a value (`/dev/null` on Unix-like OSes, `NUL` or `NUL:` on Windows).
+
+[source,ruby]
+----
+# bad - hardcoded devices are platform specific
+File.open("/dev/null", 'w') { ... }
+
+# bad - unnecessary ternary can be replaced with `File::NULL`
+File.open(Gem.win_platform? ? 'NUL' : '/dev/null', 'w') { ... }
+
+# good - platform independent
+File.open(File::NULL, 'w') { ... }
+----
+
 == Assignment & Comparison
 
 === Parallel Assignment [[parallel-assignment]]

--- a/README.adoc
+++ b/README.adoc
@@ -2165,6 +2165,12 @@ rescue StandardError => e
 end
 ----
 
+=== Standard Exceptions [[standard-exceptions]]
+
+Prefer the use of exceptions from the standard library over introducing new exception classes.
+
+== Files
+
 === Reading from a file [[file-read]]
 
 Use the convenience methods `File.read` or `File.binread` when only reading a file start to finish in a single operation.
@@ -2287,10 +2293,6 @@ end
 # good - atomic and idempotent removal
 FileUtils.rm_f(path)
 ----
-
-=== Standard Exceptions [[standard-exceptions]]
-
-Prefer the use of exceptions from the standard library over introducing new exception classes.
 
 == Assignment & Comparison
 


### PR DESCRIPTION
Follows https://github.com/rubocop/rubocop/pull/13493#issuecomment-2499825487

Also I extracted existing file guides into a separate section because they had made their way inside the Exceptions section.