### PR TITLE
Add section for empty lines after module inclusion methods

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -564,6 +564,30 @@ some_method
 some_method
 ----
 
+=== Empty Lines after Module Inclusion [[empty-lines-after-module-inclusion]]
+
+Use empty lines after module inclusion methods (`extend`, `include` and `prepend`).
+
+[source,ruby]
+----
+# bad
+class Foo
+  extend SomeModule
+  include AnotherModule
+  prepend YetAnotherModule
+  def foo; end
+end
+
+# good
+class Foo
+  extend SomeModule
+  include AnotherModule
+  prepend YetAnotherModule
+
+  def foo; end
+end
+----
+
 === Empty Lines around Attribute Accessor [[empty-lines-around-attribute-accessor]]
 
 Use empty lines around attribute accessor.


### PR DESCRIPTION
Adds a section for keeping empty lines after module inclusion methods (`extend`, `include` and `prepend`). The term "module inclusion" has been borrowed from [Layout/ClassStructure docs](https://github.com/rubocop/rubocop/blob/48363660a8b48679470e3d174461b234ddcbb02e/lib/rubocop/cop/layout/class_structure.rb#L12). I couldn't find a similar issue or PR (either here or for RuboCop).

Under this style, code such as:
```ruby
module Foo
  include Bar
  def baz; end
end
```
wouldn't be acceptable; there would have to be an empty line after `include` line:
```ruby
module Foo
  include Bar

  def baz; end
end
```

This style is suggested — though not made explicit — by [Consistent Classes](https://rubystyle.guide/#consistent-classes) and [module_function](https://rubystyle.guide/#module-function) sections of the guide ([Prefer public_send](https://rubystyle.guide/#prefer-public-send) section's example also shows this practice).

[This GH search](https://github.com/search?q=%2F(%3F-i)%5E%5Cs*(extend%7Cprepend%7Cinclude)%20%5BA-Z%5D.*%5Cn%5E%5Cs*(end)%3F%24%2F%20language%3ARuby&type=code) shows examples where module inclusion methods have been followed by an empty line or the keyword `end` (cca 2M at the time of writing). And [this search](https://github.com/search?q=%2F(%3F-i)%5E%5Cs*(extend%7Cprepend%7Cinclude)%20%5BA-Z%5D.*%5Cn%5E.*%5CS.*%24%2F%20language%3ARuby&type=code) shows examples where the methods have been followed by a non-empty line (cca 844k results; note that this search includes many false positives, like grouped `include` lines, so there are even fewer actual examples).

Some codebases where this style is mostly followed:
- [RuboCop](https://github.com/search?q=repo%3Amastodon%2Fmastodon%20%2F%5E%5Cs*(include%7Cextend%7Cprepend)%20%2F%20language%3ARuby&type=code&p=1) (there are some exceptions, for example [here](https://github.com/rubocop/rubocop/blob/48363660a8b48679470e3d174461b234ddcbb02e/lib/rubocop/cop/lint/useless_numeric_operation.rb#L33-L34), but these seem to be the minority)
- [Mastodon](https://github.com/search?q=repo%3Amastodon%2Fmastodon%20%2F%5E%5Cs*(include%7Cextend%7Cprepend)%20%2F%20language%3ARuby&type=code&p=1)
- [brew](https://github.com/search?q=repo%3Ahomebrew%2Fbrew%20%2F%5E%5Cs*(include%7Cextend%7Cprepend)%20%2F%20language%3ARuby&type=code)
- [Discourse](https://github.com/search?q=repo%3Adiscourse%2Fdiscourse%20%2F%5E%5Cs*(include%7Cextend%7Cprepend)%20%2F%20language%3ARuby&type=code&p=1)
- [rspec-core](https://github.com/search?q=repo%3Arspec%2Frspec-core%20%2F%5E%5Cs*(include%7Cextend%7Cprepend)%20%2F%20language%3ARuby&type=code&p=1)

There's also no RuboCop cop for this style, so, if accepted, a new cop would have to be implemented.

