### PR TITLE
Fix mention of deprecated Gem dependency method

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5736,7 +5736,7 @@ Fix by either:
 
 === `add_dependency` vs `add_runtime_dependency` [[add_dependency_vs_add_runtime_dependency]]
 
-Prefer `add_dependency` over `add_runtime_dependency` because `add_dependency` is considered soft-deprecated
+Prefer `add_dependency` over `add_runtime_dependency` because `add_runtime_dependency` is considered soft-deprecated
 and the Bundler team recommends `add_dependency`.
 
 [source,ruby]


### PR DESCRIPTION
This fixes the mention of a soft-deprecated Gem dependency method to say `add_runtime_dependency` and not `add_dependency` (that's the one you _should_ use).