### PR TITLE
Add Reraising exceptions rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1968,6 +1968,31 @@ fail SomeException, 'message'
 raise SomeException, 'message'
 ----
 
+=== Reraising exceptions [[reraising-exceptions]]
+
+Call `raise` without an exception argument when reraising exceptions.
+
+[source,ruby]
+----
+# bad
+begin
+  something_that_might_fail
+rescue SomeException => e
+  # handle SomeException
+
+  raise e
+end
+
+# good
+begin
+  something_that_might_fail
+rescue SomeException => e
+  # handle SomeException
+
+  raise
+end
+----
+
 === Raising Explicit `RuntimeError` [[no-explicit-runtimeerror]]
 
 Don't specify `RuntimeError` explicitly in the two argument version of `raise`.


### PR DESCRIPTION
Adds a section to prefer [reraising exceptions](https://docs.ruby-lang.org/en/3.4/exceptions_md.html#label-Re-Raising+an+Exception) implicitly, i.e. calling `raise` without an argument.

Explicit and implicit reraise are functionally equivalent (the same exception and backtrace are used), so this would be a stylistic convention foremost.

Related RuboCop PR: https://github.com/rubocop/rubocop/pull/14429 (there is some discussion already, see https://github.com/rubocop/rubocop/pull/14429#issuecomment-3163964007)

Both styles seem to be equally performant:
```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [x86_64-darwin23]
Warming up --------------------------------------
    Implicit reraise    12.739k i/100ms
    Explicit reraise    12.749k i/100ms
Calculating -------------------------------------
    Implicit reraise    128.919k (± 1.1%) i/s    (7.76 μs/i) -    649.689k in   5.040198s
    Explicit reraise    128.057k (± 1.4%) i/s    (7.81 μs/i) -    650.199k in   5.078367s

Comparison:
    Implicit reraise:   128918.6 i/s
    Explicit reraise:   128057.4 i/s - same-ish: difference falls within error
```

<details>
<summary>Benchmark script</summary>

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report('Implicit reraise') do
    begin
      raise 'boom'
    rescue => e
      raise
    end
  rescue
  end

  x.report('Explicit reraise') do
    begin
      raise 'boom'
    rescue => e
      raise e
    end
  rescue
  end

  x.compare!
end
```
</details>

I will attach a real-world report in the next comment.